### PR TITLE
Adds Windows support list to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,17 @@
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0"},
     {"name":"puppetlabs-registry","version_requirement":">= 1.1.3"}
   ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "windows",
+      "operatingsystemrelease": [
+        "2008R2",
+        "2012",
+        "2012R2",
+        "2016"
+      ]
+    }
+  ],
   "data_provider": null
 }
 


### PR DESCRIPTION
Allows finding an NTP module for Windows on the forge